### PR TITLE
Fix loading issue with hero-image on JS

### DIFF
--- a/assets/static/js/main-singlelayout.js
+++ b/assets/static/js/main-singlelayout.js
@@ -169,10 +169,10 @@ https://github.com/spyder-ide/lektor-icon/blob/master/NOTICE.txt
 
   // Document on DOM ready
   $(function () {
+    setHeroHeight();
     loaderPage();
     fh5coTabs();
     parallax();
-    setHeroHeight();
     scrolledWindow();
     clickMenu();
     navigationSection();

--- a/assets/static/js/main-singlelayout.js
+++ b/assets/static/js/main-singlelayout.js
@@ -36,7 +36,7 @@ https://github.com/spyder-ide/lektor-icon/blob/master/NOTICE.txt
 
   const setHeroHeight = function () {
     heroHeight();
-    $(window).on("resize", heroHeight);
+    $(window).bind("resize", heroHeight);
   };
 
   // Loading animation
@@ -168,7 +168,6 @@ https://github.com/spyder-ide/lektor-icon/blob/master/NOTICE.txt
 
   // Document on DOM ready
   $(function () {
-    setHeroHeight();
     loaderPage();
     fh5coTabs();
     parallax();
@@ -178,5 +177,10 @@ https://github.com/spyder-ide/lektor-icon/blob/master/NOTICE.txt
     if (mailchimpButtonEnabled) {
       setMailchimpEvent();
     }
+  });
+
+  // Document when all assets are fully loaded
+  $(window).bind("load", function () {
+    setHeroHeight();
   });
 })();

--- a/assets/static/js/main-singlelayout.js
+++ b/assets/static/js/main-singlelayout.js
@@ -36,7 +36,8 @@ https://github.com/spyder-ide/lektor-icon/blob/master/NOTICE.txt
 
   const setHeroHeight = function () {
     heroHeight();
-    $(window).bind("resize", heroHeight);
+    $(window).on("load", heroHeight);
+    $(window).on("resize", heroHeight);
   };
 
   // Loading animation
@@ -171,16 +172,12 @@ https://github.com/spyder-ide/lektor-icon/blob/master/NOTICE.txt
     loaderPage();
     fh5coTabs();
     parallax();
+    setHeroHeight();
     scrolledWindow();
     clickMenu();
     navigationSection();
     if (mailchimpButtonEnabled) {
       setMailchimpEvent();
     }
-  });
-
-  // Document when all assets are fully loaded
-  $(window).bind("load", function () {
-    setHeroHeight();
   });
 })();


### PR DESCRIPTION
There is a small isue when firing the `setHeroHeight()` function, firing before the hero image is completely loaded. This PR aims to solve that. I changed the event that fires the function from `document.ready` to `window.load`, binding the function to the load event, and to the resize event. 